### PR TITLE
Work around ${env:PATH} messing up path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
     "name": "spin-vscode",
-    "version": "0.0.1",
+    "version": "0.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "0.0.1",
+            "name": "spin-vscode",
+            "version": "0.3.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "download": "^8.0.0",

--- a/src/commands/add-to-terminal-path.ts
+++ b/src/commands/add-to-terminal-path.ts
@@ -3,12 +3,7 @@ import * as vscode from 'vscode';
 import { isErr } from '../errorable';
 import { ensureSpinInstalled } from '../installer';
 
-export async function addToTerminalPath() {
-    const osId = os();
-    if (!osId) {
-        await vscode.window.showErrorMessage('Unable to establish OS to add path for');
-        return;
-    }
+export async function addToTerminalPath(context: vscode.ExtensionContext) {
     const spinPath = await ensureSpinInstalled();
     if (isErr(spinPath)) {
         await vscode.window.showErrorMessage(`Unable to install Spin: ${spinPath.message}`);
@@ -16,41 +11,10 @@ export async function addToTerminalPath() {
     }
     const spinDirectory = path.dirname(spinPath.value);
 
-    const envSection = vscode.workspace.getConfiguration(`terminal.integrated.env`);
-    const envValues = envSection.get<EnvDictionary>(osId) || {};
-    const existingPath = envValues["PATH"];
+    const prepend = `${spinDirectory}${separator()}`;
+    context.environmentVariableCollection.prepend("PATH", prepend);
 
-    const newPath = await prependPath(spinDirectory, existingPath);
-
-    if (newPath) {
-        envValues["PATH"] = newPath;
-        await envSection.update(osId, envValues, vscode.ConfigurationTarget.Global);
-        await vscode.window.showInformationMessage('Configuration updated. You may need to start a new integrated terminal to pick up the new path.');
-    }
-}
-
-async function prependPath(spinDirectory: string, existingPath: string | undefined): Promise<string | undefined> {
-    const dirText = escape(spinDirectory);
-    if (existingPath) {
-        if (existingPath.indexOf(dirText) >= 0) {
-            const choice = await vscode.window.showWarningMessage("The terminal path seems to already contain the Spin path.", "Add it again", "Cancel");
-            if (choice !== 'Add it again') {
-                return undefined;
-            }
-        }
-        return `${dirText}${separator()}${existingPath}`;
-    } else {
-        return `${dirText}${separator()}${"${env:PATH}"}`;
-    }
-}
-
-function os(): string | null {
-    switch (process.platform) {
-        case 'win32': return 'windows';
-        case 'darwin': return 'osx';
-        case 'linux': return 'linux';
-        default: return null;
-    }
+    await vscode.window.showInformationMessage('Path updated. If your terminal shows an alert icon, click to relaunch for new path.');
 }
 
 function separator(): string {
@@ -59,9 +23,3 @@ function separator(): string {
         default: return ':';
     }
 }
-
-function escape(text: string): string {
-    return text.replace(/\\/g, '\\\\');
-}
-
-type EnvDictionary = { [key: string]: string };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import * as tasks from './tasks';
 
 export function activate(context: vscode.ExtensionContext) {
     const disposables = [
-        vscode.commands.registerCommand('spin.addToTerminalPath', addToTerminalPath),
+        vscode.commands.registerCommand('spin.addToTerminalPath', () => addToTerminalPath(context)),
         vscode.tasks.registerTaskProvider("spin", tasks.provider()),
     ];
 


### PR DESCRIPTION
Fixes #15.

There seem to be various bugs or strange behaviours associated with modifying the path through the integrated terminal environment setting.  This tries it a different way, which seems more robust at least on WSL.