### PR TITLE
Persistent deployment environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "activationEvents": [
         "onCommand:spin.addToTerminalPath",
         "onCommand:spin.deploy",
+        "onCommand:spin.connect",
         "onTaskType:spin"
     ],
     "main": "./dist/extension.js",
@@ -34,6 +35,11 @@
                 "category": "Spin",
                 "command": "spin.deploy",
                 "title": "Deploy"
+            },
+            {
+                "category": "Spin",
+                "command": "spin.connect",
+                "title": "Connect to Deployment Environment"
             }
         ],
         "configuration": {
@@ -42,6 +48,34 @@
                 "spin.customProgramPath": {
                     "type": "string",
                     "description": "Path of a Spin binary to use instead of the auto-installed binary"
+                },
+                "spin.environments": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "The name by which this environment is identified in the user interface"
+                            },
+                            "bindleUrl": {
+                                "type": "string",
+                                "description": "The URL of the Bindle server"
+                            },
+                            "hippoUrl": {
+                                "type": "string",
+                                "description": "The URL of the Hippo server"
+                            },
+                            "hippoUsername": {
+                                "type": "string",
+                                "description": "The user name for logging into the Hippo server (note: password is held separately in the secret store)"
+                            }
+                        }
+                    },
+                    "description": "The known deployment environments"
+                },
+                "spin.activeEnvironment": {
+                    "type": "string",
+                    "description": "The currently active deployment environment"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "onCommand:spin.deploy",
         "onCommand:spin.connect",
         "onCommand:spin.openDashboard",
+        "onCommand:spin.onStatusBarItemClicked",
         "onTaskType:spin"
     ],
     "main": "./dist/extension.js",
@@ -46,6 +47,11 @@
                 "category": "Spin",
                 "command": "spin.openDashboard",
                 "title": "Open Dashboard"
+            },
+            {
+                "category": "Spin",
+                "command": "spin.onStatusBarItemClicked",
+                "title": "On Status Bar Item Clicked"
             }
         ],
         "configuration": {
@@ -90,7 +96,12 @@
                 {
                     "command": "spin.openDashboard",
                     "when": "spin.connected"
+                },
+                {
+                    "command": "spin.onStatusBarItemClicked",
+                    "when": "false"
                 }
+
             ]
         },
         "taskDefinitions": [

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "onCommand:spin.addToTerminalPath",
         "onCommand:spin.deploy",
         "onCommand:spin.connect",
+        "onCommand:spin.openDashboard",
         "onTaskType:spin"
     ],
     "main": "./dist/extension.js",
@@ -39,7 +40,12 @@
             {
                 "category": "Spin",
                 "command": "spin.connect",
-                "title": "Connect to Deployment Environment"
+                "title": "Choose Deployment Environment"
+            },
+            {
+                "category": "Spin",
+                "command": "spin.openDashboard",
+                "title": "Open Dashboard"
             }
         ],
         "configuration": {
@@ -78,6 +84,14 @@
                     "description": "The currently active deployment environment"
                 }
             }
+        },
+        "menus": {
+            "commandPalette": [
+                {
+                    "command": "spin.openDashboard",
+                    "when": "spin.connected"
+                }
+            ]
         },
         "taskDefinitions": [
             {

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -1,40 +1,6 @@
-import { activeEnvironment, FermyonEnvironment, promptSwitch, setActive } from "../fermyon/environment";
-import { FERMYON_STATUS_BAR_ITEM } from "../fermyon/statusbar";
-import { isCancelled } from "../utils/cancellable";
-import { setAmbientContext } from '../utils/context';
+import * as vscode from 'vscode';
+import { promptSwitch } from "../fermyon/environment-ui";
 
-const SPIN_CONNECTED_CONTEXT = "spin.connected";
-
-export async function connect() {
-    const environment_ = await promptSwitch();
-    if (isCancelled(environment_)) {
-        return;
-    }
-    const environment = environment_.value;
-
-    await setUI(environment);
-}
-
-export async function connectTo(environment: FermyonEnvironment | undefined) {
-    await setActive(environment?.name);
-    await setUI(environment);
-}
-
-export async function connectToActive() {
-    const environment = activeEnvironment();
-    await setUI(environment);
-}
-
-async function setUI(environment: FermyonEnvironment | undefined) {
-    if (environment === undefined) {
-        // clear status bar
-        FERMYON_STATUS_BAR_ITEM.hide();
-        // remove terminal EVs
-        await setAmbientContext(SPIN_CONNECTED_CONTEXT, false);
-    } else {
-        // update status bar
-        FERMYON_STATUS_BAR_ITEM.show(environment.name, environment.hippoUrl);
-        // update any terminal EVs, etc.
-        await setAmbientContext(SPIN_CONNECTED_CONTEXT, true);
-    }
+export async function connect(context: vscode.ExtensionContext) {
+    await promptSwitch(context);
 }

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -1,0 +1,35 @@
+import { activeEnvironment, FermyonEnvironment, promptSwitch, setActive } from "../fermyon/environment";
+import { FERMYON_STATUS_BAR_ITEM } from "../fermyon/statusbar";
+import { isCancelled } from "../utils/cancellable";
+
+export async function connect() {
+    const environment_ = await promptSwitch();
+    if (isCancelled(environment_)) {
+        return;
+    }
+    const environment = environment_.value;
+
+    setUI(environment);
+}
+
+export async function connectTo(environment: FermyonEnvironment | undefined) {
+    await setActive(environment?.name);
+    setUI(environment);
+}
+
+export function connectToActive() {
+    const environment = activeEnvironment();
+    setUI(environment);
+}
+
+function setUI(environment: FermyonEnvironment | undefined) {
+    if (environment === undefined) {
+        // clear status bar
+        FERMYON_STATUS_BAR_ITEM.hide();
+        // remove terminal EVs
+    } else {
+        // update status bar
+        FERMYON_STATUS_BAR_ITEM.show(environment.name, environment.hippoUrl);
+        // update any terminal EVs, etc.
+    }
+}

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -1,6 +1,9 @@
 import { activeEnvironment, FermyonEnvironment, promptSwitch, setActive } from "../fermyon/environment";
 import { FERMYON_STATUS_BAR_ITEM } from "../fermyon/statusbar";
 import { isCancelled } from "../utils/cancellable";
+import { setAmbientContext } from '../utils/context';
+
+const SPIN_CONNECTED_CONTEXT = "spin.connected";
 
 export async function connect() {
     const environment_ = await promptSwitch();
@@ -9,27 +12,29 @@ export async function connect() {
     }
     const environment = environment_.value;
 
-    setUI(environment);
+    await setUI(environment);
 }
 
 export async function connectTo(environment: FermyonEnvironment | undefined) {
     await setActive(environment?.name);
-    setUI(environment);
+    await setUI(environment);
 }
 
-export function connectToActive() {
+export async function connectToActive() {
     const environment = activeEnvironment();
-    setUI(environment);
+    await setUI(environment);
 }
 
-function setUI(environment: FermyonEnvironment | undefined) {
+async function setUI(environment: FermyonEnvironment | undefined) {
     if (environment === undefined) {
         // clear status bar
         FERMYON_STATUS_BAR_ITEM.hide();
         // remove terminal EVs
+        await setAmbientContext(SPIN_CONNECTED_CONTEXT, false);
     } else {
         // update status bar
         FERMYON_STATUS_BAR_ITEM.show(environment.name, environment.hippoUrl);
         // update any terminal EVs, etc.
+        await setAmbientContext(SPIN_CONNECTED_CONTEXT, true);
     }
 }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -18,36 +18,131 @@ export async function deploy(context: vscode.ExtensionContext) {
     }
     const [deployParameters, unsaved] = deployParameters_.value;
 
-    const deployResult = await longRunningProcess("Spin deploy in progress...", (tok) =>
-        spin.deploy(tok, deployParameters)
+    let state: DeployState | undefined = { state: 'deploying', parameters: deployParameters, unsaved, context };
+
+    while (state !== undefined) {
+        state = await runDeployStateMachine(state);
+    }
+}
+
+// The login failure flows were breaking my brain so time to overengineer
+// the heck out of this mofo
+
+// * deploying -> succeeded
+//                | redeploying [if already exists]
+//                | getting new credentials [if login failed]
+//                | failed
+//   redeploying -> succeeded
+//                  | getting new credentials [if login failed]
+//                  | failed
+//   getting new credentials -> redeploying [if new creds given, always redeploy because bindle upload would already have happened by this point]
+//                              | TERMINATE [if new creds prompt cancelled]
+//   succeded -> TERMINATE
+//   failed -> TERMINATE
+
+type DeployState =
+    { state: 'deploying', parameters: spin.DeployParameters, unsaved: UnsavedEnvironmentInfo, context: vscode.ExtensionContext } |
+    { state: 'succeeded', parameters: spin.DeployParameters, unsaved: UnsavedEnvironmentInfo, context: vscode.ExtensionContext, existedBefore: boolean, message: string } |
+    { state: 'failed', message: string, existedBefore: boolean } |
+    { state: 'redeploying', parameters: spin.DeployParameters, unsaved: UnsavedEnvironmentInfo, context: vscode.ExtensionContext, existedBefore: boolean } |
+    { state: 'getting-new-credentials', parameters: spin.DeployParameters, unsaved: UnsavedEnvironmentInfo, context: vscode.ExtensionContext, existedBefore: boolean };
+
+async function runDeployStateMachine(state: DeployState): Promise<DeployState | undefined> {
+    switch (state.state) {
+        case 'deploying':
+            return await runDeploy(state.parameters, state.unsaved, state.context);
+        case 'succeeded':
+            return await runSucceeded(state.parameters, state.unsaved, state.context, state.existedBefore, state.message);
+        case 'failed':
+            return await runFailed(state.message, state.existedBefore);
+        case 'redeploying':
+            return await runRedeploy(state.parameters, state.unsaved, state.context, state.existedBefore);
+        case 'getting-new-credentials':
+            return await runGettingNewCredentials(state.parameters, state.unsaved, state.context, state.existedBefore);
+        default:
+            cantHappen(state);
+    }
+}
+
+async function runDeploy(parameters: spin.DeployParameters, unsaved: UnsavedEnvironmentInfo, context: vscode.ExtensionContext): Promise<DeployState> {
+    const result = await longRunningProcess("Spin deploy in progress...", (tok) =>
+        spin.deploy(tok, parameters)
     );
 
-    if (isOk(deployResult)) {
-        // should we understand it too?
-        output.appendLine(deployResult.value);
-        output.show();
-        await notifyDeploymentComplete(unsaved, "deployment", context, deployParameters);
-    } else {
-        output.appendLine(deployResult.message);
-        const alreadyExists = deployResult.message.includes('already exists on the server');
-        if (alreadyExists) {
-            const reactivateResult = await longRunningProcess("Deployment exists, reactivating...", (tok) => 
-                spin.deploy(tok, deployParameters, true)
-            );
-            if (isOk(reactivateResult)) {
-                output.appendLine(reactivateResult.value);
-                output.show();
-                await notifyDeploymentComplete(unsaved, "deployment (reactivation)", context, deployParameters);
-            } else {
-                output.appendLine(reactivateResult.message);
-                output.show();
-                await vscode.window.showErrorMessage("Spin deployment (reactivation) failed. See Output pane for details.");
-            }
-        } else {
-            output.show();
-            await vscode.window.showErrorMessage("Spin deployment failed. See Output pane for details.");
-        }
+    if (isOk(result)) {
+        return { state: 'succeeded', parameters, unsaved, context, existedBefore: false, message: result.value };
     }
+
+    if (result.message.includes('already exists on the server')) {
+        output.appendLine(result.message);
+        return { state: 'redeploying', parameters, unsaved, context, existedBefore: true };
+    }
+
+    if (result.message.includes('Login failed')) {
+        output.appendLine(result.message);
+        return { state: 'getting-new-credentials', parameters, unsaved, context, existedBefore: false };
+    }
+
+    return { state: 'failed', message: result.message, existedBefore: false };
+}
+
+async function runSucceeded(parameters: spin.DeployParameters, unsaved: UnsavedEnvironmentInfo, context: vscode.ExtensionContext, existedBefore: boolean, message: string): Promise<undefined> {
+    output.appendLine(message);
+    output.show();
+    const description = existedBefore ? "deployment (reactivation)" : "deployment";
+    await notifyDeploymentComplete(unsaved, description, context, parameters);
+    return undefined;
+}
+
+async function runFailed(message: string, existedBefore: boolean): Promise<undefined> {
+    output.appendLine(message);
+    output.show();
+    const description = existedBefore ? "deployment (reactivation)" : "deployment";
+    await vscode.window.showErrorMessage(`Spin ${description} failed. See Output pane for details.`);
+    return undefined;    
+}
+
+async function runRedeploy(parameters: spin.DeployParameters, unsaved: UnsavedEnvironmentInfo, context: vscode.ExtensionContext, existedBefore: boolean): Promise<DeployState> {
+    const title = existedBefore ?
+        "Spin deploy in progres..." :
+        "Deployment exists, reactivating...";
+
+    const result = await longRunningProcess(title, (tok) =>
+        spin.deploy(tok, parameters, true)
+    );
+
+    if (isOk(result)) {
+        return { state: 'succeeded', parameters, unsaved, context, existedBefore, message: result.value };
+    }
+
+    if (result.message.includes('Login failed')) {
+        output.appendLine(result.message);
+        return { state: 'getting-new-credentials', parameters, unsaved, context, existedBefore: existedBefore };
+    }
+
+    return { state: 'failed', message: result.message, existedBefore: existedBefore };
+}
+
+async function runGettingNewCredentials(parameters: spin.DeployParameters, unsaved: UnsavedEnvironmentInfo, context: vscode.ExtensionContext, existedBefore: boolean): Promise<DeployState | undefined> {
+    const prompt = `Login failed. Please enter password for ${parameters.hippoUsername}`;
+    const password = await vscode.window.showInputBox({ prompt, password: true });
+    if (!password) {
+        return undefined;
+    }
+
+    const newParameters = { ...parameters, hippoPassword: password };
+
+    // What is now unsaved, given this new password?  If we were already in
+    // 'everything unsaved' (i.e. no environment) then that's still the case.
+    // If we were in already in 'password unsaved' (i.e. environment without
+    // password) then that's till the case too!  But if we were in 'nothing
+    // unsaved' (i.e. environment with password) then we need to go to 'password
+    // unsaved'.
+    const newUnsaved: UnsavedEnvironmentInfo = (unsaved.toSave === 'none') ?
+        { toSave: 'password', envName: unsaved.envName } :
+        unsaved;
+
+    return { state: 'redeploying', parameters: newParameters, unsaved: newUnsaved, context, existedBefore };
 }
 
 async function notifyDeploymentComplete(unsaved: UnsavedEnvironmentInfo, description: string, context: vscode.ExtensionContext, deployParameters: spin.DeployParameters) {
@@ -87,7 +182,7 @@ async function completeDeployParameters(context: vscode.ExtensionContext, fermyo
     if (fermyonEnv) {
         const hippoPassword = await getHippoPassword(context, fermyonEnv.name);
         if (hippoPassword) {
-            return accepted([{ hippoPassword, ...fermyonEnv}, { toSave: 'none'} ]);
+            return accepted([{ hippoPassword, ...fermyonEnv}, { toSave: 'none', envName: fermyonEnv.name }]);
         } else {
             const hippoPassword = await vscode.window.showInputBox({ prompt: `Hippo password for ${fermyonEnv.name}`, password: true });
             if (hippoPassword) {
@@ -140,4 +235,4 @@ async function envOrPrompt(env: string, promptOpts: vscode.InputBoxOptions): Pro
 type UnsavedEnvironmentInfo =
     { toSave: 'all' } |
     { toSave: 'password', envName: string } |
-    { toSave: 'none' };
+    { toSave: 'none', envName: string };

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -4,43 +4,40 @@ import * as spin from '../spin';
 import { isOk } from '../errorable';
 import * as output from '../output';
 import { longRunningProcess } from '../longrunning';
+import { activeEnvironment, FermyonEnvironment, getHippoPassword, saveEnvironment, saveHippoPassword } from '../fermyon/environment';
+import { accepted, Cancellable, cancelled, isCancelled } from '../utils/cancellable';
+import { cantHappen } from '../utils/never';
+import { connectTo } from './connect';
 
-const BONUS_ENV: { [key: string]: string } = {};
+export async function deploy(context: vscode.ExtensionContext) {
+    const fermyonEnv = activeEnvironment();
 
-export async function deploy() {
-    if (!await ensureEnv("BINDLE_URL", { prompt: "Enter Bindle server URL", placeHolder: "http://bindle.local.fermyon.link/v1" })) {
+    const deployParameters_ = await completeDeployParameters(context, fermyonEnv);
+    if (isCancelled(deployParameters_)) {
         return;
     }
-    if (!await ensureEnv("HIPPO_URL", { prompt: "Enter Hippo server URL", placeHolder: "http://hippo.local.fermyon.link" })) {
-        return;
-    }
-    if (!await ensureEnv("HIPPO_USERNAME", { prompt: "Enter Hippo user name", placeHolder: "myname" })) {
-        return;
-    }
-    if (!await ensureEnv("HIPPO_PASSWORD", { prompt: "Enter Hippo password", placeHolder: "my$s3cr3t!", password: true })) {
-        return;
-    }
+    const [deployParameters, unsaved] = deployParameters_.value;
 
     const deployResult = await longRunningProcess("Spin deploy in progress...", (tok) =>
-        spin.deploy(tok, BONUS_ENV)
+        spin.deploy(tok, deployParameters)
     );
 
     if (isOk(deployResult)) {
         // should we understand it too?
         output.appendLine(deployResult.value);
         output.show();
-        await vscode.window.showInformationMessage("Spin deployment complete. See Output pane for application URL.");
+        await notifyDeploymentComplete(unsaved, "deployment", context, deployParameters);
     } else {
         output.appendLine(deployResult.message);
         const alreadyExists = deployResult.message.includes('already exists on the server');
         if (alreadyExists) {
             const reactivateResult = await longRunningProcess("Deployment exists, reactivating...", (tok) => 
-                spin.deploy(tok, BONUS_ENV, true)
+                spin.deploy(tok, deployParameters, true)
             );
             if (isOk(reactivateResult)) {
                 output.appendLine(reactivateResult.value);
                 output.show();
-                await vscode.window.showInformationMessage("Spin deployment (reactivation) complete. See Output pane for application URL.");
+                await notifyDeploymentComplete(unsaved, "deployment (reactivation)", context, deployParameters);
             } else {
                 output.appendLine(reactivateResult.message);
                 output.show();
@@ -53,16 +50,91 @@ export async function deploy() {
     }
 }
 
-async function ensureEnv(env: string, promptOpts: vscode.InputBoxOptions): Promise<boolean> {
-    if (process.env[env]) {
-        return true;
+async function notifyDeploymentComplete(unsaved: UnsavedEnvironmentInfo, description: string, context: vscode.ExtensionContext, deployParameters: spin.DeployParameters) {
+    const message = `Spin ${description} complete. See output pane for application URL.`;
+    if (unsaved.toSave === 'none') {
+        await vscode.window.showInformationMessage(message);
+    } else if (unsaved.toSave === 'password') {
+        const savePassword = await vscode.window.showInformationMessage(message, "Save Password");
+        if (savePassword) {
+            await saveHippoPassword(context, unsaved.envName, deployParameters.hippoPassword);
+        }
+    } else if (unsaved.toSave === 'all') {
+        const saveAll = await vscode.window.showInformationMessage(message, "Save Deployment Settings", "Save Without Password");
+        if (saveAll) {
+            const envName = await vscode.window.showInputBox({ prompt: "Pick a name for these settings" });
+            if (!envName) {
+                return;
+            }
+            const environment = {
+                name: envName,
+                bindleUrl: deployParameters.bindleUrl,
+                hippoUrl: deployParameters.hippoUrl,
+                hippoUsername: deployParameters.hippoUsername,
+            };
+            await saveEnvironment(context, environment, deployParameters.hippoPassword);
+            connectTo(environment);
+        }
+    } else {
+        cantHappen(unsaved);
+    }
+}
+
+async function completeDeployParameters(context: vscode.ExtensionContext, fermyonEnv: FermyonEnvironment | undefined): Promise<Cancellable<[spin.DeployParameters, UnsavedEnvironmentInfo]>> {
+    if (fermyonEnv) {
+        const hippoPassword = await getHippoPassword(context, fermyonEnv.name);
+        if (hippoPassword) {
+            return accepted([{ hippoPassword, ...fermyonEnv}, { toSave: 'none'} ]);
+        } else {
+            const hippoPassword = await vscode.window.showInputBox({ prompt: `Hippo password for ${fermyonEnv.name}`, password: true });
+            if (hippoPassword) {
+                return accepted([{ hippoPassword, ...fermyonEnv}, { toSave: 'password', envName: fermyonEnv.name }]);
+            } else {
+                return cancelled();
+            }
+        }
+    } else {
+        const deployParameters = await promptOrEnvDeploymentParameters();
+        if (isCancelled(deployParameters)) {
+            return cancelled();
+        } else {
+            return accepted([deployParameters.value, { toSave: 'all' }]);
+        }
+    }
+}
+
+async function promptOrEnvDeploymentParameters(): Promise<Cancellable<spin.DeployParameters>> {
+    const bindleUrl = await envOrPrompt("BINDLE_URL", { prompt: "Enter Bindle server URL", placeHolder: "http://bindle.local.fermyon.link/v1", ignoreFocusOut: true });
+    if (!bindleUrl) {
+        return cancelled();
+    }
+    const hippoUrl = await envOrPrompt("HIPPO_URL", { prompt: "Enter Hippo server URL", placeHolder: "http://hippo.local.fermyon.link", ignoreFocusOut: true });
+    if (!hippoUrl) {
+        return cancelled();
+    }
+    const hippoUsername = await envOrPrompt("HIPPO_USERNAME", { prompt: "Enter Hippo user name", placeHolder: "name", ignoreFocusOut: true });
+    if (!hippoUsername) {
+        return cancelled();
+    }
+    const hippoPassword = await envOrPrompt("HIPPO_PASSWORD", { prompt: "Enter Hippo password", password: true, ignoreFocusOut: true });
+    if (!hippoPassword) {
+        return cancelled();
     }
 
-    promptOpts.value = BONUS_ENV[env];
-    const envValue = await vscode.window.showInputBox(promptOpts);
-    if (!envValue) {
-        return false;
-    }
-    BONUS_ENV[env] = envValue;
-    return true;
+    return accepted({
+        bindleUrl,
+        hippoUrl,
+        hippoUsername,
+        hippoPassword,
+    });
 }
+
+async function envOrPrompt(env: string, promptOpts: vscode.InputBoxOptions): Promise<string | undefined> {
+    return process.env[env] ||
+        await vscode.window.showInputBox(promptOpts);
+}
+
+type UnsavedEnvironmentInfo =
+    { toSave: 'all' } |
+    { toSave: 'password', envName: string } |
+    { toSave: 'none' };

--- a/src/commands/openDashboard.ts
+++ b/src/commands/openDashboard.ts
@@ -1,0 +1,22 @@
+import * as vscode from 'vscode';
+
+import { activeEnvironment } from "../fermyon/environment";
+
+export async function openDashboard() {
+    const environment = activeEnvironment();
+    if (!environment) {
+        // Shouldn't happen because of UI context but just in case
+        await vscode.window.showErrorMessage('Not connected to Fermyon. Choose Spin: Choose Deployment Environment.');
+        return;
+    }
+
+    try {
+        const hippoUrl = vscode.Uri.parse(environment.hippoUrl);
+        const opened = await vscode.env.openExternal(hippoUrl);
+        if (!opened) {
+            await vscode.window.showErrorMessage(`Unable to open ${environment.hippoUrl}.`);
+        }
+    } catch {
+        await vscode.window.showErrorMessage(`Invalid dashboard URL ${environment.hippoUrl}. Please update your settings.`);
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,10 @@
 import * as vscode from 'vscode';
 
 import { addToTerminalPath } from './commands/add-to-terminal-path';
-import { connect, connectToActive } from './commands/connect';
+import { connect } from './commands/connect';
 import { deploy } from './commands/deploy';
 import { openDashboard } from './commands/openDashboard';
+import { showActiveEnvironmentUI } from './fermyon/environment-ui';
 
 import * as tasks from './tasks';
 
@@ -11,14 +12,14 @@ export async function activate(context: vscode.ExtensionContext) {
     const disposables = [
         vscode.commands.registerCommand('spin.addToTerminalPath', () => addToTerminalPath(context)),
         vscode.commands.registerCommand('spin.deploy', () => deploy(context)),
-        vscode.commands.registerCommand('spin.connect', connect),
+        vscode.commands.registerCommand('spin.connect', () => connect(context)),
         vscode.commands.registerCommand('spin.openDashboard', openDashboard),
         vscode.tasks.registerTaskProvider("spin", tasks.provider()),
     ];
 
     context.subscriptions.push(...disposables);
 
-    await connectToActive();
+    await showActiveEnvironmentUI(context);
 }
 
 export function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { connect } from './commands/connect';
 import { deploy } from './commands/deploy';
 import { openDashboard } from './commands/openDashboard';
 import { showActiveEnvironmentUI } from './fermyon/environment-ui';
+import { onStatusBarItemClicked } from './fermyon/statusbar';
 
 import * as tasks from './tasks';
 
@@ -13,6 +14,7 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('spin.addToTerminalPath', () => addToTerminalPath(context)),
         vscode.commands.registerCommand('spin.deploy', () => deploy(context)),
         vscode.commands.registerCommand('spin.connect', () => connect(context)),
+        vscode.commands.registerCommand('spin.onStatusBarItemClicked', onStatusBarItemClicked),
         vscode.commands.registerCommand('spin.openDashboard', openDashboard),
         vscode.tasks.registerTaskProvider("spin", tasks.provider()),
     ];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { addToTerminalPath } from './commands/add-to-terminal-path';
+import { connect, connectToActive } from './commands/connect';
 import { deploy } from './commands/deploy';
 
 import * as tasks from './tasks';
@@ -8,9 +9,12 @@ import * as tasks from './tasks';
 export function activate(context: vscode.ExtensionContext) {
     const disposables = [
         vscode.commands.registerCommand('spin.addToTerminalPath', () => addToTerminalPath(context)),
-        vscode.commands.registerCommand('spin.deploy', deploy),
+        vscode.commands.registerCommand('spin.deploy', () => deploy(context)),
+        vscode.commands.registerCommand('spin.connect', connect),
         vscode.tasks.registerTaskProvider("spin", tasks.provider()),
     ];
+
+    connectToActive();
 
     context.subscriptions.push(...disposables);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,20 +3,22 @@ import * as vscode from 'vscode';
 import { addToTerminalPath } from './commands/add-to-terminal-path';
 import { connect, connectToActive } from './commands/connect';
 import { deploy } from './commands/deploy';
+import { openDashboard } from './commands/openDashboard';
 
 import * as tasks from './tasks';
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
     const disposables = [
         vscode.commands.registerCommand('spin.addToTerminalPath', () => addToTerminalPath(context)),
         vscode.commands.registerCommand('spin.deploy', () => deploy(context)),
         vscode.commands.registerCommand('spin.connect', connect),
+        vscode.commands.registerCommand('spin.openDashboard', openDashboard),
         vscode.tasks.registerTaskProvider("spin", tasks.provider()),
     ];
 
-    connectToActive();
-
     context.subscriptions.push(...disposables);
+
+    await connectToActive();
 }
 
 export function deactivate() {

--- a/src/fermyon/environment-ui.ts
+++ b/src/fermyon/environment-ui.ts
@@ -1,0 +1,89 @@
+import * as vscode from 'vscode';
+import { accepted, Cancellable, cancelled } from '../utils/cancellable';
+import { setAmbientContext } from '../utils/context';
+import { activeEnvironment, activeEnvironmentNameConfig, allEnvironmentsConfig, FermyonEnvironment, getHippoPassword, saveActive } from './environment';
+import { FERMYON_STATUS_BAR_ITEM } from './statusbar';
+
+const SPIN_CONNECTED_CONTEXT = "spin.connected";
+
+// Proposed experience:
+// - You can have multiple environments defined
+// - You can have an active environment or no active environment
+// - If you have an active environment then it is used for deployment operations
+// - If not then it uses the current logic
+
+export async function promptSwitch(context: vscode.ExtensionContext): Promise<Cancellable<FermyonEnvironment | undefined>> {
+    const activeEnvironmentName = activeEnvironmentNameConfig();
+    const allEnvironments = allEnvironmentsConfig();
+
+    if (allEnvironments.length === 0) {
+        await vscode.window.showInformationMessage("There are no other Fermyon environments defined.");
+        return cancelled();
+    }
+
+    const otherEnvironments = allEnvironments.filter(e => e.name !== activeEnvironmentName);
+    const quickPicks = otherEnvironments.map(asQuickPick);
+    quickPicks.unshift({ label: '(None)', description: 'Disconnects from all environments', environment: undefined });
+
+    const selected = await vscode.window.showQuickPick(
+        quickPicks,
+        { placeHolder: 'Environment to switch to' }
+    );
+    if (!selected) {
+        return cancelled();
+    }
+
+    const selectedEnvironment = selected.environment;
+    await setActive(context, selectedEnvironment);
+    return accepted(selectedEnvironment);
+}
+
+export async function setActive(context: vscode.ExtensionContext, environment: FermyonEnvironment | undefined) {
+    await saveActive(environment?.name);
+    await setUI(context, environment);
+}
+
+export async function showActiveEnvironmentUI(context: vscode.ExtensionContext) {
+    const environment = activeEnvironment();
+    await setUI(context, environment);
+}
+
+function asQuickPick(environment: FermyonEnvironment): vscode.QuickPickItem & { readonly environment: FermyonEnvironment | undefined } {
+    return {
+        label: environment.name,
+        description: `(dashboard: ${environment.hippoUrl})`,
+        environment,
+    };
+}
+
+async function setUI(context: vscode.ExtensionContext, environment: FermyonEnvironment | undefined) {
+    if (environment === undefined) {
+        FERMYON_STATUS_BAR_ITEM.hide();
+        await clearTerminalEnvironment(context);
+        await setAmbientContext(SPIN_CONNECTED_CONTEXT, false);
+    } else {
+        FERMYON_STATUS_BAR_ITEM.show(environment.name, environment.hippoUrl);
+        await setTerminalEnvironment(context, environment);
+        await setAmbientContext(SPIN_CONNECTED_CONTEXT, true);
+    }
+}
+
+async function setTerminalEnvironment(context: vscode.ExtensionContext, environment: FermyonEnvironment) {
+    context.environmentVariableCollection.replace("BINDLE_URL", environment.bindleUrl);
+    context.environmentVariableCollection.replace("HIPPO_URL", environment.hippoUrl);
+    context.environmentVariableCollection.replace("HIPPO_USERNAME", environment.hippoUsername);
+
+    const hippoPassword = await getHippoPassword(context, environment.name);
+    if (hippoPassword) {
+        context.environmentVariableCollection.replace("HIPPO_PASSWORD", hippoPassword);
+    } else {
+        context.environmentVariableCollection.delete("HIPPO_PASSWORD");
+    }
+}
+
+async function clearTerminalEnvironment(context: vscode.ExtensionContext) {
+    context.environmentVariableCollection.delete("BINDLE_URL");
+    context.environmentVariableCollection.delete("HIPPO_URL");
+    context.environmentVariableCollection.delete("HIPPO_USERNAME");
+    context.environmentVariableCollection.delete("HIPPO_PASSWORD");
+}

--- a/src/fermyon/environment.ts
+++ b/src/fermyon/environment.ts
@@ -64,7 +64,7 @@ export async function promptSwitch(): Promise<Cancellable<FermyonEnvironment | u
 
     const otherEnvironments = allEnvironments.filter(e => e.name !== activeEnvironmentName);
     const quickPicks = otherEnvironments.map(asQuickPick);
-    quickPicks.unshift({ label: 'Disconnect', environment: undefined });
+    quickPicks.unshift({ label: '(None)', description: 'Disconnects from all environments', environment: undefined });
 
     const selected = await vscode.window.showQuickPick(
         quickPicks,

--- a/src/fermyon/environment.ts
+++ b/src/fermyon/environment.ts
@@ -1,0 +1,105 @@
+import * as vscode from 'vscode';
+import { accepted, Cancellable, cancelled } from '../utils/cancellable';
+
+// Proposed experience:
+// - You can have multiple environments defined
+// - You can have an active environment or no active environment
+// - If you have an active environment then it is used for deployment operations
+// - If not then it uses the current logic
+
+// Longer term we may need to split this - not sure whether we should
+// simply infer Terraform directories etc.
+export interface FermyonEnvironment {
+    readonly name: string;
+    // readonly kind: 'local' | 'aws';
+    readonly bindleUrl: string;
+    readonly hippoUrl: string;
+    readonly hippoUsername: string;
+}
+
+export function activeEnvironment(): FermyonEnvironment | undefined {
+    const activeEnvironmentName = activeEnvironmentNameConfig();
+    const allEnvironments = allEnvironmentsConfig();
+    const activeEnvironment = allEnvironments.find(e => e.name === activeEnvironmentName);
+    return activeEnvironment;
+}
+
+function hippoPasswordKey(environment: string): string {
+    return `fermyon.${environment}.hippo.password`;
+}
+
+export async function getHippoPassword(context: vscode.ExtensionContext, environment: string): Promise<string | undefined> {
+    const key = hippoPasswordKey(environment);
+    return await context.secrets.get(key);
+}
+
+export async function saveHippoPassword(context: vscode.ExtensionContext, environment: string, password: string) {
+    const key = hippoPasswordKey(environment);
+    await context.secrets.store(key, password);
+}
+
+export async function saveEnvironment(context: vscode.ExtensionContext, environment: FermyonEnvironment, hippoPassword: string | undefined) {
+    const allEnvironments = allEnvironmentsConfig();
+    const existing = allEnvironments.findIndex(e => e.name === environment.name);
+    if (existing >= 0) {
+        allEnvironments.splice(existing, 1, environment);
+    } else {
+        allEnvironments.push(environment);
+    }
+    vscode.workspace.getConfiguration().update("spin.environments", allEnvironments, vscode.ConfigurationTarget.Global);
+
+    if (hippoPassword) {
+        await saveHippoPassword(context, environment.name, hippoPassword);
+    }
+}
+
+export async function promptSwitch(): Promise<Cancellable<FermyonEnvironment | undefined>> {
+    const activeEnvironmentName = activeEnvironmentNameConfig();
+    const allEnvironments = allEnvironmentsConfig();
+
+    if (allEnvironments.length === 0) {
+        await vscode.window.showInformationMessage("There are no other Fermyon environments defined.");
+        return cancelled();
+    }
+
+    const otherEnvironments = allEnvironments.filter(e => e.name !== activeEnvironmentName);
+    const quickPicks = otherEnvironments.map(asQuickPick);
+    quickPicks.unshift({ label: 'Disconnect', environment: undefined });
+
+    const selected = await vscode.window.showQuickPick(
+        quickPicks,
+        { placeHolder: 'Environment to switch to' }
+    );
+    if (!selected) {
+        return cancelled();
+    }
+
+    const selectedEnvironment = selected.environment;
+    await setActive(selectedEnvironment?.name);
+    return accepted(selectedEnvironment);
+}
+
+function activeEnvironmentNameConfig() {
+    return vscode.workspace.getConfiguration().get<string>("spin.activeEnvironment");
+}
+
+function allEnvironmentsConfig() {
+    return vscode.workspace.getConfiguration().get<FermyonEnvironment[]>("spin.environments") || [];
+}
+
+export async function setActive(environmentName: string | undefined) {
+    await vscode.workspace.getConfiguration().update("spin.activeEnvironment", environmentName, vscode.ConfigurationTarget.Global);
+}
+
+export function environmentExists(environmentName: string): boolean {
+    const allEnvironments = allEnvironmentsConfig();
+    return allEnvironments.some(e => e.name === environmentName);
+}
+
+function asQuickPick(environment: FermyonEnvironment): vscode.QuickPickItem & { readonly environment: FermyonEnvironment | undefined } {
+    return {
+        label: environment.name,
+        description: `(dashboard: ${environment.hippoUrl})`,
+        environment,
+    };
+}

--- a/src/fermyon/statusbar.ts
+++ b/src/fermyon/statusbar.ts
@@ -19,6 +19,7 @@ class FermyonStatusBarItemImpl implements FermyonStatusBarItem {
         if (this.item === null) {
             this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right);
             this.item.text = "Fermyon";
+            this.item.command = "spin.onStatusBarItemClicked";
         }
         this.item.tooltip = `Dashboard URL: ${dashboardAddress}\nData environment: ${environmentName}`;
         this.item.show();
@@ -28,6 +29,21 @@ class FermyonStatusBarItemImpl implements FermyonStatusBarItem {
         if (this.item !== null) {
             this.item.hide();
         }
+    }
+}
+
+export async function onStatusBarItemClicked() {
+    // TODO: is there a way to keep these in sync with the titles in
+    // package.json?
+    const commands = [
+        { label: "Spin: Choose Deployment Environment", command: "spin.connect" },
+        { label: "Spin: Open Dashboard", command: "spin.openDashboard" },
+    ];
+
+    const commandPick = await vscode.window.showQuickPick(commands);
+
+    if (commandPick) {
+        vscode.commands.executeCommand(commandPick.command);
     }
 }
 

--- a/src/fermyon/statusbar.ts
+++ b/src/fermyon/statusbar.ts
@@ -1,0 +1,34 @@
+import * as vscode from 'vscode';
+
+export interface FermyonStatusBarItem {
+    show(environmentName: string, dashboardAddress: string): void;
+    hide(): void;
+}
+
+export function newStatusBarItem(): FermyonStatusBarItem {
+    return new FermyonStatusBarItemImpl();
+}
+
+class FermyonStatusBarItemImpl implements FermyonStatusBarItem {
+    private item: vscode.StatusBarItem | null;
+    constructor() {
+        this.item = null;
+    }
+
+    show(environmentName: string, dashboardAddress: string) {
+        if (this.item === null) {
+            this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right);
+            this.item.text = "Fermyon";
+        }
+        this.item.tooltip = `Dashboard URL: ${dashboardAddress}\nData environment: ${environmentName}`;
+        this.item.show();
+    }
+
+    hide() {
+        if (this.item !== null) {
+            this.item.hide();
+        }
+    }
+}
+
+export const FERMYON_STATUS_BAR_ITEM: FermyonStatusBarItem = new FermyonStatusBarItemImpl();

--- a/src/spin.ts
+++ b/src/spin.ts
@@ -32,7 +32,7 @@ import * as shell from './utils/shell';
 //     return await invokeObj(sh, 'deploy', args, {}, (s) => s);
 // }
 
-export async function deploy(token: CancellationToken, bonusEnv: { [key: string]: string }, reactivateExisting?: boolean): Promise<Errorable<shell.RunningProcess>> {
+export async function deploy(token: CancellationToken, parameters: DeployParameters, reactivateExisting?: boolean): Promise<Errorable<shell.RunningProcess>> {
     const binOpt = await ensureSpinInstalled();
     if (isErr(binOpt)) {
         return binOpt;
@@ -40,5 +40,22 @@ export async function deploy(token: CancellationToken, bonusEnv: { [key: string]
     const bin = binOpt.value;
 
     const args = reactivateExisting ? ['--deploy-existing-bindle'] : [];
+    const bonusEnv = toEnv(parameters);
     return ok(shell.invokeErrFeed(bin, ['deploy', ...args], bonusEnv, token));
+}
+
+export interface DeployParameters {
+    readonly bindleUrl: string;
+    readonly hippoUrl: string;
+    readonly hippoUsername: string;
+    readonly hippoPassword: string;
+}
+
+function toEnv(deployParameters: DeployParameters): { [key: string]: string } {
+    return {
+        BINDLE_URL: deployParameters.bindleUrl,
+        HIPPO_URL: deployParameters.hippoUrl,
+        HIPPO_USERNAME: deployParameters.hippoUsername,
+        HIPPO_PASSWORD: deployParameters.hippoPassword,
+    };
 }

--- a/src/utils/cancellable.ts
+++ b/src/utils/cancellable.ts
@@ -1,0 +1,26 @@
+export interface Accepted<T> {
+    readonly accepted: true;
+    readonly value: T;
+}
+
+export interface Cancelled {
+    readonly accepted: false;
+}
+
+export type Cancellable<T> = Accepted<T> | Cancelled;
+
+export function isAccepted<T>(c: Cancellable<T>): c is Accepted<T> {
+    return c.accepted;
+}
+
+export function isCancelled<T>(c: Cancellable<T>): c is Cancelled {
+    return !c.accepted;
+}
+
+export function accepted<T>(value: T): Cancellable<T> {
+    return { accepted: true, value };
+}
+
+export function cancelled(): Cancelled {
+    return { accepted: false };
+}

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,0 +1,5 @@
+import * as vscode from 'vscode';
+
+export async function setAmbientContext(name: string, value: unknown) {
+    await vscode.commands.executeCommand('setContext', name, value);
+}


### PR DESCRIPTION
This allows a set of deployment parameters (Bindle URL, Hippo URL, etc.) to be saved as an 'environment.'  The current environment is remembered from session to session, and is automatically used for future deployments.  You can switch between environments, or disconnect from all of them.  If the user does a successful deployment when there _isn't_ an environment, we offer to save the parameters as a new environment.

A status bar item shows the current environment in a hover tip, and you can click it to switch environments or open the Hippo dashboard.